### PR TITLE
set shortand

### DIFF
--- a/examples/generators.nox
+++ b/examples/generators.nox
@@ -1,7 +1,7 @@
 // 3..6 is shorthand for range(3, 6), a lazy iterable
 // Tuple(3..6) on a dynamic range is illegal as it cannot be typed
 
-// Set(3..6) or {3..6} would produce { 3,4,5,6 }
+// Set(3..6) or #{3..6} would produce #{ 3,4,5,6 }
 // List(3..6) or [3..6] would produce [ 3,4,5,6 ]
 // Dict(x: 1 for x in 3..6) or {x: 1 for x in 3..6} would produce {3:1,4:1,5:1,6:1}
 

--- a/examples/ranges.nox
+++ b/examples/ranges.nox
@@ -29,7 +29,7 @@ range(10, 3, -1)  // 10, 9, 8, 7, 6, 5, 4
 // Like any generator, you can decide what collection type to "flow" the
 // generator into if you want to consume it:
 [0..7] == List(0..7) == [0, 1, 2, 3, 4, 5, 6]
-{0..7} == Set(0..7) == {0, 1, 2, 3, 4, 5, 6}
+#{0..7} == Set(0..7) == #{0, 1, 2, 3, 4, 5, 6}
 Tuple(0..7) == (0, 1, 2, 3, 4, 5, 6, 7)
 
 // Note that (0..7) is just the expression `0..7` wrapped in parens, which does
@@ -41,7 +41,7 @@ Tuple(0..7) == (0, 1, 2, 3, 4, 5, 6, 7)
 // comprehensions, since they are infinite, and building lists or sets from
 // them would consume up all memory (and more)
 [3..]  // not allowed
-{3..}  // not allowed
+#{3..}  // not allowed
 
 // Using infinite ranges to build infinite generators is fine, though.
 // Like this infinite list of all even numbers larger than 3, squared:

--- a/examples/sets.nox
+++ b/examples/sets.nox
@@ -1,8 +1,9 @@
 // Sugar:
-// x | y is sugar for Set.union(s1, s2)
-// x & y is sugar for Set.intersection(s1, s2)
+// #{x, y} is sugar for Set(x, y)
+// #{x..y} is sugar for Set(x..y)
+// s1 | s2 is sugar for Set.union(s1, s2)
+// s1 & s2 is sugar for Set.intersection(s1, s2)
 
-// sugar
 func union(s1: Set<T>, s2: Set<T>): Set<T> {
   return s1 | s2
 }
@@ -15,9 +16,11 @@ func union(s1: Set<T>, s2: Set<T>): Set<T> {
     | _                 -> (s2, s1)
 
   // set comprehension
-  return { for (x in smallest) => if (x in largest) => x }
+  return #{ for (x in smallest) => if (x in largest) => x }
 }
 
 func intersection(s1: Set<T>, s2: Set<T>): Set<T> {
   return s1 & s2
 }
+
+


### PR DESCRIPTION
Suggestion to change Set notation "shorthand" to `#{ .. }` from `{ .. }` to distinguish from Dicts